### PR TITLE
Sanitize optional param assume_role if provided

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,6 @@ function main() {
   sanitize "${INPUT_REGION}" "region"
   sanitize "${INPUT_ACCOUNT_ID}" "account_id"
   sanitize "${INPUT_REPO}" "repo"
-  sanitize "${INPUT_ASSUME_ROLE}" "assume_role"
 
   ACCOUNT_URL="$INPUT_ACCOUNT_ID.dkr.ecr.$INPUT_REGION.amazonaws.com"
 
@@ -41,6 +40,7 @@ function login() {
 
 function assume_role() {
   if [ "${INPUT_ASSUME_ROLE}" != "" ]; then
+    sanitize "${INPUT_ASSUME_ROLE}" "assume_role"
     echo "== START ASSUME ROLE"
     ROLE="arn:aws:iam::${INPUT_ACCOUNT_ID}:role/${INPUT_ASSUME_ROLE}"
     CREDENTIALS=$(aws sts assume-role --role-arn ${ROLE} --role-session-name ecrpush --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text)


### PR DESCRIPTION
sanitizing empty `assume_role` results in error
Sanitizing it after presence check prevents it

```sh
bash-3.2$ sanitize "" "assume_role"
Unable to find the assume_role. Did you set with.assume_role?
```